### PR TITLE
git submodules updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 env:
   CACHE_VERSION_LINUX: 15

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, pull_request]
 
 env:
   CACHE_VERSION_LINUX: 15


### PR DESCRIPTION
Updated submodules, main intent to pull in PawPaw changes to support changed linker options on newer MacOS builds.

Submodule path 'src/PawPaw': checked out '45aa5eef69da8aee1bc9385f8381107031c7655e'
Submodule path 'src/mod-app-asio': checked out '34e9bd655ebaabb63bc9d182a6d0e7d0a291f7d7'
Submodule path 'src/mod-ui': checked out 'c5e4f5d10cfd5d696b99ee338598948527f7f11b'